### PR TITLE
Remove outdated dependabot config section

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,11 +32,3 @@ updates:
     # # Managed by cisagov/cool-iam-user-group-manager-iam
     # ignore:
     #   - dependency-name: "hashicorp/aws"
-
-  - package-ecosystem: "terraform"
-    directory: "/examples/basic_usage"
-    schedule:
-      interval: "weekly"
-    # # Managed by cisagov/cool-iam-user-group-manager-iam
-    # ignore:
-    #   - dependency-name: "hashicorp/aws"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,6 +29,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    # # Managed by cisagov/cool-iam-user-group-manager-iam
-    # ignore:
-    #   - dependency-name: "hashicorp/aws"
+    # Managed by cisagov/skeleton-tf-module
+    ignore:
+      - dependency-name: "hashicorp/aws"


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##
This PR removes an outdated section of the dependabot config and also adds the ignore directive for Terraform, since that is handled by `cisagov/skeleton-tf-module`.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

I removed the `/examples/basic_usage` directory in PR #4, but neglected to remove the corresponding dependabot config section.  I also forgot to enable the dependabot ignore directive for Terraform.  This PR remedies those oversights.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Visual inspection.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
